### PR TITLE
Add NTv2 Globogis vector transformation for Italy

### DIFF
--- a/DETransformProvider.py
+++ b/DETransformProvider.py
@@ -41,6 +41,7 @@ from ntv2_transformations.VectorES_ED50ERTS89DirInv import VectorES_ED50ERTS89Di
 from ntv2_transformations.RasterES_ED50ERTS89DirInv import RasterES_ED50ERTS89DirInv
 from ntv2_transformations.VectorIT_RER_ETRS89DirInv import VectorIT_RER_ETRS89DirInv
 from ntv2_transformations.RasterIT_RER_ETRS89DirInv import RasterIT_RER_ETRS89DirInv
+from ntv2_transformations.VectorIT_ITALY_ETRS89DirInv import VectorIT_ITALY_ETRS89DirInv
 from ntv2_transformations.VectorCH_LV95ETRS89DirInv import VectorCH_LV95ETRS89DirInv
 from ntv2_transformations.RasterCH_LV95ETRS89DirInv import RasterCH_LV95ETRS89DirInv
 from ntv2_transformations.VectorUK_OSGB36ETRS89DirInv import VectorUK_OSGB36ETRS89DirInv
@@ -106,6 +107,7 @@ class DETransformProvider(QgsProcessingProvider):
                 RasterES_ED50ERTS89DirInv(),
                 VectorIT_RER_ETRS89DirInv(),
                 RasterIT_RER_ETRS89DirInv(),
+                VectorIT_ITALY_ETRS89DirInv(),
                 VectorCH_LV95ETRS89DirInv(),
                 RasterCH_LV95ETRS89DirInv(),
                 VectorUK_OSGB36ETRS89DirInv(),

--- a/RasterIT_RER_ETRS89DirInv.py
+++ b/RasterIT_RER_ETRS89DirInv.py
@@ -60,10 +60,10 @@ class RasterIT_RER_ETRS89DirInv(GdalAlgorithm):
         return 'itrastertransform'
 
     def displayName(self):
-        return '[IT] Direct and inverse Raster Transformation'
+        return '[IT] (Emilia Romagna) Raster - Direct and inverse Transformation'
 
     def group(self):
-        return '[IT] Italy (Emilia-Romagna)'
+        return '[IT] Italy'
 
     def groupId(self):
         return 'italy'
@@ -86,7 +86,7 @@ class RasterIT_RER_ETRS89DirInv(GdalAlgorithm):
                        ('UTM - ED50 [EPSG:23032]', 23032),
                       )
 
-        self.grids = (('Grigliati NTv2 RER 2013 la trasformazione di coordinate in Emilia-Romagna', 'RER_ETRS89'),
+        self.grids = (('Grigliati NTv2 RER 2013 per la trasformazione di coordinate in Emilia-Romagna', 'RER_ETRS89'),
                      )
 
         self.addParameter(QgsProcessingParameterRasterLayer(self.INPUT,

--- a/VectorIT_ITALY_ETRS89DirInv.py
+++ b/VectorIT_ITALY_ETRS89DirInv.py
@@ -2,7 +2,7 @@
 
 """
 ***************************************************************************
-    VectorIT_RER_ETRS89DirInv.py
+    VectorIT_ITALY_ETRS89DirInv.py
     ---------------------
     Date                 : August 2019
     Copyright            : (C) 2019 by Giovanni Manghi
@@ -44,7 +44,7 @@ from ntv2_transformations.transformations import it_transformation
 pluginPath = os.path.dirname(__file__)
 
 
-class VectorIT_RER_ETRS89DirInv(GdalAlgorithm):
+class VectorIT_ITALY_ETRS89DirInv(GdalAlgorithm):
 
     INPUT = 'INPUT'
     TRANSF = 'TRANSF'
@@ -56,10 +56,10 @@ class VectorIT_RER_ETRS89DirInv(GdalAlgorithm):
         super().__init__()
 
     def name(self):
-        return 'itrervectortransform'
+        return 'itvectortransform'
 
     def displayName(self):
-        return '[IT] (Emilia-Romagna) Vector - Direct and inverse Transformation'
+        return '[IT] (Italy) Vector - Direct and inverse Transformation'
 
     def group(self):
         return '[IT] Italy'
@@ -71,7 +71,7 @@ class VectorIT_RER_ETRS89DirInv(GdalAlgorithm):
         return 'vector,grid,ntv2,direct,inverse,italy'.split(',')
 
     def shortHelpString(self):
-        return 'Direct and inverse vector transformations using Italy (Emilia-Romagna) NTv2 grids.'
+        return 'Direct and inverse vector transformations using Globogis NTv2 grids.'
 
     def icon(self):
         return QIcon(os.path.join(pluginPath, 'icons', 'it.png'))
@@ -81,11 +81,13 @@ class VectorIT_RER_ETRS89DirInv(GdalAlgorithm):
                            'Inverse: ETRS89 [EPSG:4258] -> Old Data'
                           ]
 
-        self.datums = (('Monte Mario - GBO [EPSG:3003]', 3003),
-                       ('UTM - ED50 [EPSG:23032]', 23032),
+        self.datums = (('Monte Mario - GBO Italy 1 [EPSG:3003]', 3003),
+                       ('Monte Mario - GBO Italy 2 [EPSG:3004]', 3004),
+                       ('UTM - ED50 32N [EPSG:23033]', 23032),
+                       ('UTM - ED50 33N [EPSG:23033]', 23033),
                       )
 
-        self.grids = (('Grigliati NTv2 RER 2013 per la trasformazione di coordinate in Emilia-Romagna', 'RER_ETRS89'),
+        self.grids = (('Grigliati NTv2 Globogis per la trasformazione di coordinate in Italia', 'ITALY_ETRS89'),
                      )
 
         self.addParameter(QgsProcessingParameterFeatureSource(self.INPUT,
@@ -156,12 +158,12 @@ class VectorIT_RER_ETRS89DirInv(GdalAlgorithm):
             arguments.append('ogr2ogr')
             arguments.append('-f {}'.format(outputFormat))
             arguments.append('-a_srs')
-            arguments.append('EPSG:3003')
+            arguments.append('EPSG:{}'.format(epsg))
             arguments.append(output)
             arguments.append('/vsistdin/')
 
-        if not os.path.isfile(os.path.join(pluginPath, 'grids', 'RER_AD400_MM_ETRS89_V1A.gsb')):
-            urlretrieve('http://www.naturalgis.pt/downloads/ntv2grids/it_rer/RER_AD400_MM_ETRS89_V1A.gsb', os.path.join(pluginPath, 'grids', 'RER_AD400_MM_ETRS89_V1A.gsb'))
-            urlretrieve('http://www.naturalgis.pt/downloads/ntv2grids/it_rer/RER_ED50_ETRS89_GPS7_K2.GSB', os.path.join(pluginPath, 'grids', 'RER_ED50_ETRS89_GPS7_K2.GSB'))
+        if not os.path.isfile(os.path.join(pluginPath, 'grids', 'NadRoma40.gsb')):
+            urlretrieve('http://www.naturalgis.pt/downloads/ntv2grids/it_globo/NadRoma40.gsb', os.path.join(pluginPath, 'grids', 'NadRoma40.gsb'))
+            urlretrieve('http://www.naturalgis.pt/downloads/ntv2grids/it_globo/NadED50.gsb', os.path.join(pluginPath, 'grids', 'NadED50.gsb'))
 
         return ['ogr2ogr', GdalUtils.escapeAndJoin(arguments)]

--- a/transformations.py
+++ b/transformations.py
@@ -111,6 +111,19 @@ def it_transformation(epsg, grid):
         elif epsg == 23032:
             gridFile = os.path.join(pluginPath, 'grids', 'RER_ED50_ETRS89_GPS7_K2.GSB')
             return True, '+proj=utm +zone=32 +ellps=intl +nadgrids={} +wktext +units=m +no_defs'.format(gridFile)
+    elif grid == 'ITALY_ETRS89':
+        if epsg == 3003:
+            gridFile = os.path.join(pluginPath, 'grids', 'NadRoma40.gsb')
+            return True, '+proj=tmerc +lat_0=0 +lon_0=9 +k=0.9996 +x_0=1500000 +y_0=0 +ellps=intl +nadgrids={} +wktext +units=m +no_defs'.format(gridFile)
+        elif epsg == 3004:
+            gridFile = os.path.join(pluginPath, 'grids', 'NadRoma40.gsb')
+            return True, '+proj=tmerc +lat_0=0 +lon_0=15 +k=0.9996 +x_0=2520000 +y_0=0 +ellps=intl +nadgrids={} +wktext +units=m +no_defs'.format(gridFile)
+        elif epsg == 23032:
+            gridFile = os.path.join(pluginPath, 'grids', 'NadED50.gsb')
+            return True, '+proj=utm +zone=32 +ellps=intl +nadgrids={} +wktext +units=m +no_defs'.format(gridFile)
+        elif epsg == 23033:
+            gridFile = os.path.join(pluginPath, 'grids', 'NadED50.gsb')
+            return True, '+proj=utm +zone=33 +ellps=intl +nadgrids={} +wktext +units=m +no_defs'.format(gridFile)
 
     return False, NO_TRANSFORMATION
 


### PR DESCRIPTION
I've slightly modified VectorIT_RER_ETRS89DirInv.py to create a vector transformation for Italy VectorIT_ITALY_ETRS89DirInv.py using the Globogis NTv2 grids.

It seems working, but I don't know if there are other changes to make in other parts of the code...

I'm unsure about these lines https://github.com/agiudiceandrea/naturalgis_ntv2_transformations/blob/b94b7b4da906bdefdecb6f98154fef29405a6b30/VectorIT_ITALY_ETRS89DirInv.py#L4-L22

and particularly this https://github.com/agiudiceandrea/naturalgis_ntv2_transformations/blob/b94b7b4da906bdefdecb6f98154fef29405a6b30/VectorIT_ITALY_ETRS89DirInv.py#L59

If all is ok with this code, I'll also try to create a RasterIT_ITALY_ETRS89DirInv.py.

By the way, I've found there's something not working properly in the ogr2ogr command for all the vector inverse transformations.
The log reports "_Warning 6: dataset /vsistdout/ does not support layer creation option ENCODING_" every time an inverse transformation is performed.
I wonder why /vsistdout/  and /vsistdin/ are needed in order to perform the vector inverse transformations and if we could avoid to use them.

I would also point out that two other NTv2 gridfiles are available for Italy at http://www.provincia.agrigento.it/flex/cm/pages/ServeBLOB.php/L/IT/IDPagina/309: these grids are created using the Geoportale Nazionale coordinate transform service http://www.pcn.minambiente.it/mattm/conversione-coordinate/ for ROMA40<->WGS84/ETRS89-ETRF89 and ED50<->WGS84/ETRS89-ETRF89
Could them be added to the gridfiles repository?

Partially fixes #29